### PR TITLE
Implemented the GraphQL field value builder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,9 @@
         }
     ],
     "minimum-stability": "stable",
-    "require": {},
+    "require": {
+        "bdunogier/ezplatform-graphql-bundle": "^0.4@dev"
+    },
     "autoload": {
         "psr-4": {
             "BD\\PlatformQueryFieldType\\": "src/BD/PlatformQueryFieldType/src/lib",

--- a/src/bundle/Resources/config/fieldtypes.yml
+++ b/src/bundle/Resources/config/fieldtypes.yml
@@ -8,3 +8,5 @@ services:
         tags:
             - { name: ez.fieldFormMapper.definition, fieldType: query }
             - { name: ez.fieldFormMapper.value, fieldType: query }
+        arguments:
+            $contentTypeService: '@ezpublish.api.service.content_type'

--- a/src/bundle/Resources/config/graphql.yml
+++ b/src/bundle/Resources/config/graphql.yml
@@ -7,3 +7,7 @@ services:
     BD\PlatformQueryFieldType\GraphQL\Resolver\QueryFieldResolver:
         tags:
             - { name: overblog_graphql.resolver, alias: "QueryFieldValue", method: "resolveQueryField" }
+
+    BD\PlatformQueryFieldType\GraphQL\QueryFieldValueBuilder:
+        tags:
+            - { name: ezplatform_graphql.field_value_builder, type: 'query'}

--- a/src/bundle/Resources/views/field_types.html.twig
+++ b/src/bundle/Resources/views/field_types.html.twig
@@ -7,6 +7,12 @@
         {{- form_widget(form.QueryType) -}}
     </div>
 
+    <div class="query-returned-type{% if group_class is not empty %} {{ group_class }}{% endif %}">
+        {{- form_label(form.ReturnedType) -}}
+        {{- form_errors(form.ReturnedType) -}}
+        {{- form_widget(form.ReturnedType) -}}
+    </div>
+
     <div class="query-parameters{% if group_class is not empty %} {{ group_class }}{% endif %}">
         {{- form_label(form.Parameters) -}}
         {{- form_errors(form.Parameters) -}}

--- a/src/lib/FieldType/Query/Type.php
+++ b/src/lib/FieldType/Query/Type.php
@@ -16,6 +16,7 @@ class Type extends FieldType
     protected $settingsSchema = [
         'QueryType' => ['type' => 'string', 'default' => ''],
         'Parameters' => ['type' => 'string', 'default' => ''],
+        'ReturnedType' => ['type' => 'string', 'default' => ''],
     ];
 
 

--- a/src/lib/GraphQL/QueryFieldValueBuilder.php
+++ b/src/lib/GraphQL/QueryFieldValueBuilder.php
@@ -1,0 +1,60 @@
+<?php
+namespace BD\PlatformQueryFieldType\GraphQL;
+
+use BD\EzPlatformGraphQLBundle\DomainContent\FieldValueBuilder\FieldValueBuilder;
+use BD\EzPlatformGraphQLBundle\DomainContent\NameHelper;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\QueryType\QueryTypeRegistry;
+
+class QueryFieldValueBuilder implements FieldValueBuilder
+{
+    /**
+     * @var QueryTypeRegistry
+     */
+    private $queryTypeRegistry;
+
+    /**
+     * @var NameHelper
+     */
+    private $nameHelper;
+    /**
+     * @var ContentTypeService
+     */
+    private $contentTypeService;
+
+    public function __construct(
+        QueryTypeRegistry $queryTypeRegistry,
+        NameHelper $nameHelper,
+        ContentTypeService $contentTypeService
+    ){
+        $this->queryTypeRegistry = $queryTypeRegistry;
+        $this->nameHelper = $nameHelper;
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @param FieldDefinition $fieldDefinition
+     * @return array GraphQL definition array for the Field Value
+     */
+    public function buildDefinition(FieldDefinition $fieldDefinition)
+    {
+        $fieldSettings = $fieldDefinition->getFieldSettings();
+
+
+        return [
+            'type' => '[' . $this->getDomainTypeName($fieldSettings['ReturnedType']) . ']',
+            'resolve' => sprintf(
+                '@=resolver("QueryFieldValue", [value, "%s"])',
+                $fieldDefinition->identifier
+            ),
+        ];
+    }
+
+    private function getDomainTypeName($typeIdentifier)
+    {
+        return $this->nameHelper->domainContentName(
+            $this->contentTypeService->loadContentTypeByIdentifier($typeIdentifier)
+        );
+    }
+}

--- a/src/lib/Persistence/Legacy/Content/FieldValue/Converter/QueryConverter.php
+++ b/src/lib/Persistence/Legacy/Content/FieldValue/Converter/QueryConverter.php
@@ -57,6 +57,7 @@ class QueryConverter implements Converter
     public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
     {
         $storageDef->dataText1 = $fieldDef->fieldTypeConstraints->fieldSettings['QueryType'];
+        $storageDef->dataText2 = $fieldDef->fieldTypeConstraints->fieldSettings['ReturnedType'];
         $storageDef->dataText5 = $fieldDef->fieldTypeConstraints->fieldSettings['Parameters'];
     }
 
@@ -70,6 +71,7 @@ class QueryConverter implements Converter
     {
         $fieldDef->fieldTypeConstraints->fieldSettings = [
             'QueryType' => $storageDef->dataText1 ?: null,
+            'ReturnedType' => $storageDef->dataText2 ?: null,
             'Parameters' => $storageDef->dataText5 ?: ''
         ];
     }


### PR DESCRIPTION
Enables the Field Type to generate its own GraphQL definition. Adds a `ReturnedType` setting that determines which type is returned by the Query, so that the definition can set the exact domain type.